### PR TITLE
Update URL for DLFNova

### DIFF
--- a/app/src/main/java/com/lit/fronuis/Radio.java
+++ b/app/src/main/java/com/lit/fronuis/Radio.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  *
  * DLF Nova: https://st03.sslstream.dlf.de/dlf/03/128/mp3/stream.mp3
  * https://onlineradiobox.com/de/dradiowissen
- * https://www.deutschlandfunknova.de/actions/dradio/playlist/onair
+ * https://static.deutschlandfunknova.de/actions/dradio/playlist/onair
  *
  * WDR 5: https://wdr-wdr5-live.icecastssl.wdr.de/wdr/wdr5/live/mp3/128/stream.mp3
  * https://onlineradiobox.com/de/wdr5/


### PR DESCRIPTION
Gude,

ich arbeite für die Codemonauts und wir hosten die Webseite vom Deutschlandfunk. Vor kurzem hat sich die onair URL für das Webradio geändert und ich hab deinen Code über die Suche von Github gefunden und die URL mal angepasst. Aktuell laufen beide noch parallel aber falls du die URL anfängst du nutzen, gerne direkt die neue URL verwenden :)


Viele Grüße,
Felix